### PR TITLE
Update who-apply.html

### DIFF
--- a/one-time-canada-housing-benefit-payment/who-apply.html
+++ b/one-time-canada-housing-benefit-payment/who-apply.html
@@ -692,10 +692,11 @@ margin-left: -2.0em;
             <li class="checkbox">
               <input type="checkbox" id="eg6" class="action-checkbox cb-dmm">
               <label for="eg6">
-                <p>The 2022 eligible rent that you paid for your principal residence in Canada:</p>
+                <p>The eligible rent that you paid was:</p>
                 <ul>
-                  <li>was paid within the 2022 calendar year</li>
-                  <li>was equal to at least 30% of your 2021 adjusted family net income</li>
+                  <li>paid in the 2022 calendar year</li>
+                  <li>paid for any of your qualifying principal residences in 2022</li>
+                  <li>equal to at least 30% of your 2021 adjusted family net income</li>
                 </ul>
                 <!-- <p><strong>In 2022</strong>, you paid at least 30% of your 2021 adjusted family net income on eligible rent for your own principal residence in Canada</p> -->
                 <p class="mrgn-tp-md">Find out <a href="what-eligible-rent.html">what you can include as eligible rent</a>.</p>


### PR DESCRIPTION
The eligible rent that you paid was:
- paid in the 2022 calendar year
- paid for any of your qualifying principal residences in 2022
- equal to at least 30% of your 2021 adjusted family net income